### PR TITLE
Should resolve mixed content warnings on opensource.indeedend.io

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,15 +16,15 @@
         <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/styles.css">
         <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/indeed-styles.css">
         <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/subscribe.css">
-       
 
-        <link rel="shortcut icon" href="http://rac4ou2q3g246tjk3rxqbt1c.wpengine.netdna-cdn.com/wp-content/themes/indeedblog/favicon.ico" />
+
+        <link rel="shortcut icon" href="https://rac4ou2q3g246tjk3rxqbt1c-wpengine.netdna-ssl.com/wp-content/themes/indeedblog/favicon.ico" />
 
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <!--[if lt IE 9]>
         <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
         <![endif]-->
-        
+
     </head>
     <body>
       <div id="blogHeader" class="full-width-wrapper">
@@ -39,7 +39,7 @@
                   <span class="icon-bar"></span>
                 </button>
                 <a href="http://engineering.indeedblog.com/" class="navbar-brand">
-	                <img src="http://rac4ou2q3g246tjk3rxqbt1c.wpengine.netdna-cdn.com/wp-content/themes/indeedblog/images/ind-eng-logo.png" alt="Indeed Engineering" width="300" scale="0">
+	                <img src="https://rac4ou2q3g246tjk3rxqbt1c-wpengine.netdna-ssl.com/wp-content/themes/indeedblog/images/ind-eng-logo.png" alt="Indeed Engineering" width="300" scale="0">
 		        </a>
               </div>
               <div id="headerNavLinks" class="collapse navbar-collapse">
@@ -71,7 +71,7 @@
         {% if page.exclude_toc == nil or page.exclude_toc == false %}
         <script src="{{ site.baseurl }}/assets/js/toc.js"></script>
         {% endif %}
-        
+
 	{% include analytics.html %}
     </body>
 </html>


### PR DESCRIPTION
We enabled the setting to enforce https on opensource.indeedeng.io, and now that page is throwing mixed content warnings. This PR should resolve them.