### PR TITLE
Fix deprecated pygments warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 name: Indeed Engineering Open Source
 # http://stackoverflow.com/questions/10759577/underscore-issues-jekyll-redcarpet-github-flavored-markdown
 markdown: redcarpet
-highlighter: pygments
+highlighter: rouge
 # jekyll serve --watch --baseurl=
 # permalinks are relative to their parent folder
 relative_permalinks: false


### PR DESCRIPTION
On the last Jekyll build of the site pages, the following warning was thrown:

You are attempting to use the 'pygments' highlighter, which is currently unsupported on GitHub Pages. Your site will use 'rouge' for highlighting instead. To suppress this warning, change the 'highlighter' value to 'rouge' in your '_config.yml' and ensure the 'pygments' key is unset. For more information, see https://help.github.com/en/articles/page-build-failed-config-file-error#fixing-highlighting-errors.

Updating the _config.yml to address the issue.